### PR TITLE
Build for Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:wheezy
+FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND noninteractive
 MAINTAINER antti@bitalo.com
 ADD proxmox.list /etc/apt/sources.list.d/proxmox.list
-ADD http://download.proxmox.com/debian/key.asc /tmp/key.asc
-RUN apt-key add /tmp/key.asc \
- && apt-get update \
- && apt-get install -y pve-qemu-kvm
+ADD --chown=_apt:root http://download.proxmox.com/debian/proxmox-release-bookworm.gpg /etc/apt/trusted.gpg.d
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y pve-qemu-kvm zstd lzop gzip \
+ && apt-get clean -m \
+ && rm -r /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Introduction
 
-Dockerfile to build a Debian Wheezy image
+Dockerfile to build a Debian Bookworm image
 with the Proxmox [vma](http://pve.proxmox.com/wiki/VMA#Command_line_utility)
 command line utility
 

--- a/proxmox.list
+++ b/proxmox.list
@@ -1,1 +1,1 @@
-deb http://download.proxmox.com/debian wheezy pve
+deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription


### PR DESCRIPTION
Note that this is using the ` pve-no-subscription` repository.

I'm also installing zstd, lzop, and gzip since Proxmox backups can be compressed with these formats and the vma can't handle these compressed images itself.